### PR TITLE
fix: typo in Engine, `theese` > `these`

### DIFF
--- a/Engine/Step.cs
+++ b/Engine/Step.cs
@@ -82,7 +82,7 @@ namespace DotNetCoreKoans.Engine
                 console.WriteLine();
             }
 
-            console.WriteLine("Ponder the meaning in theese lines:".Cyan());
+            console.WriteLine("Ponder the meaning in these lines:".Cyan());
             console.WriteLine($"{String.Join('\n', Exception.GetStackTracePaths())}".Cyan());
         }
     }


### PR DESCRIPTION
From https://github.com/NotMyself/DotNetCoreKoans/pull/161